### PR TITLE
Use _POSIX_HOST_NAME_MAX instead of HOST_NAME_MAX.

### DIFF
--- a/vendor/project_acpc_server/kuhn_3p_equilibrium_player/src/dealer_connection.h
+++ b/vendor/project_acpc_server/kuhn_3p_equilibrium_player/src/dealer_connection.h
@@ -10,7 +10,7 @@ Copyright (C) 2013 by the Computer Poker Research Group, University of Alberta
 #include <stdio.h>
 
 typedef struct {
-  char host[HOST_NAME_MAX];
+  char host[_POSIX_HOST_NAME_MAX];
   uint16_t port;
   FILE *toServer;
   FILE *fromServer;

--- a/vendor/project_acpc_server/kuhn_3p_equilibrium_player/src/player_config.c
+++ b/vendor/project_acpc_server/kuhn_3p_equilibrium_player/src/player_config.c
@@ -157,8 +157,9 @@ static void get_host(command_t *self)
 
   PlayerConfig* config = self->data;
 
-  memset(config->dealer.host, 0, HOST_NAME_MAX * sizeof(*config->dealer.host));
-  strncpy(config->dealer.host, self->arg, HOST_NAME_MAX);
+  memset(config->dealer.host, 0,
+         _POSIX_HOST_NAME_MAX * sizeof(*config->dealer.host));
+  strncpy(config->dealer.host, self->arg, _POSIX_HOST_NAME_MAX);
 }
 
 static void get_port(command_t *self)


### PR DESCRIPTION
The latter does not exist on OS X.

Also tested on debian jessie.