### PR TITLE
Add braces to sub-object initializer.

### DIFF
--- a/vendor/project_acpc_server/kuhn_3p_equilibrium_player/vendor/cexception/lib/CException.c
+++ b/vendor/project_acpc_server/kuhn_3p_equilibrium_player/vendor/cexception/lib/CException.c
@@ -1,6 +1,6 @@
 #include "CException.h"
 
-volatile CEXCEPTION_FRAME_T CExceptionFrames[CEXCEPTION_NUM_ID] = { 0 };
+volatile CEXCEPTION_FRAME_T CExceptionFrames[CEXCEPTION_NUM_ID] = { { 0 } };
 
 //------------------------------------------------------------------------------------------
 //  Throw


### PR DESCRIPTION
Avoids warning from gcc.
